### PR TITLE
Feature/old teams

### DIFF
--- a/src/components/OldTeamsRow.tsx
+++ b/src/components/OldTeamsRow.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+
+interface OldTeamsRowProps {
+  teams: Array<{
+    year: string;
+    members: Array<{
+      image: string;
+      name: string;
+      title: string;
+      linkedinURL?: string;
+      description?: string;
+    }>;
+  }>;
+}
+
+const OldTeamsRow: React.FC<OldTeamsRowProps> = ({ teams }) => {
+  return (
+    <div className="mt-24">
+      <h2 className="text-3xl font-bold mb-8 text-center bg-clip-text text-transparent bg-gradient-to-r from-white to-neutral-400">
+        Previous Teams
+      </h2>
+      <div className="space-y-16">
+        {teams.map((team) => (
+          <div key={team.year} className="mb-8">
+            <h3 className="text-xl font-semibold mb-4 text-center text-primary">{team.year}</h3>
+            <div className="flex flex-wrap justify-center gap-6">
+              {team.members.filter(m => m.name).map((member) => (
+                <div
+                  key={member.name + member.title}
+                  className="flex flex-col items-center bg-neutral-900/80 rounded-2xl p-4 w-56 border border-neutral-800"
+                >
+                  <img
+                    src={member.image}
+                    alt={member.name}
+                    className="w-24 h-24 object-cover rounded-xl border border-neutral-700 mb-2"
+                  />
+                  <div className="text-center">
+                    <div className="font-semibold text-neutral-200">{member.name}</div>
+                    <div className="text-primary text-sm mb-1">{member.title}</div>
+                    {member.description && (
+                      <div className="text-neutral-400 text-xs mb-1">{member.description}</div>
+                    )}
+                    {member.linkedinURL && (
+                      <a
+                        href={member.linkedinURL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-block mt-1 text-primary hover:underline"
+                      >
+                        LinkedIn
+                      </a>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default OldTeamsRow;

--- a/src/components/TeamDisplay.tsx
+++ b/src/components/TeamDisplay.tsx
@@ -8,6 +8,8 @@ import {
 } from "framer-motion";
 import { Member } from "@/types/team";
 import teamData from "@/data/team.json";
+import oldTeamsData from "@/data/old-teams.json";
+import OldTeamsRow from "./OldTeamsRow";
 import { FaLinkedin } from "react-icons/fa";
 
 interface TeamMemberCardProps {
@@ -288,7 +290,6 @@ const TeamDisplay = () => {
         <AppScrollDetector />
         <FloatingLights />
 
-        {}
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -302,6 +303,8 @@ const TeamDisplay = () => {
             startIndex={0}
           />
         </div>
+
+        <OldTeamsRow teams={oldTeamsData.teams} />
       </div>
     </ScrollDirectionContext.Provider>
   );

--- a/src/data/old-teams.json
+++ b/src/data/old-teams.json
@@ -1,0 +1,368 @@
+{
+    "teams": [
+        {
+            "year": "2024-2025",
+            "members": [
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Awwab Mahdi",
+                    "description": "Current obsession: Lord of the Mysteries",
+                    "title": "Co-President",
+                    "linkedinURL": "https://www.linkedin.com/in/awwabm",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Tarek Sallam",
+                    "description": "Current obsession: Deep Learning",
+                    "title": "Co-President",
+                    "linkedinURL": "https://www.linkedin.com/in/tareksallam",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Diego Fuentes",
+                    "description": "Current obsession: Holistic Health and Wellness",
+                    "title": "VP Academics",
+                    "linkedinURL": "https://www.linkedin.com/in/diego-fuentesa",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Kierra Blankespoor",
+                    "description": "Current Obsession: Dinner rolls",
+                    "title": "VP Community",
+                    "linkedinURL": "https://www.linkedin.com/in/kierra-blankespoor",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Vaibhav Panchanadam",
+                    "description": "Current obsession: blue by young kai",
+                    "title": "VP Events",
+                    "linkedinURL": "https://www.linkedin.com/in/vaibhav-panchanadam",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Mohamed Bouslama",
+                    "description": "Current obsession: Game dev",
+                    "title": "VP Events",
+                    "linkedinURL": "https://www.linkedin.com/in/mohamed-bouslama-2092892b1",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Tarek Ibrahim",
+                    "description": "Current obsession: Go",
+                    "title": "VP Projects and Technology",
+                    "linkedinURL": "https://www.linkedin.com/in/im-tarek",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Zeeshan Jahangir",
+                    "description": "Current obsession: Collecting Fake Internet Points",
+                    "title": "VP Finance",
+                    "linkedinURL": "https://www.linkedin.com/in/zeeshan-jahangir-604ba762",
+                    "linkedin": "/linkedin.svg"
+                }
+            ]
+        },
+        {
+            "year": "2023-2024",
+            "members": [
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Enos Odigie",
+                    "title": "Co-President",
+                    "linkedinURL": "https://www.linkedin.com/in/enosodigie/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Gordon Tang",
+                    "title": "Co-President & VP Finance",
+                    "linkedinURL": "https://www.linkedin.com/in/gordon-tang-2023/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Kanishk Patoliya",
+                    "title": "VP External and Events",
+                    "linkedinURL": "https://www.linkedin.com/in/kanishk-patoliya/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Nadia Uddin",
+                    "title": "Events Coordinator",
+                    "linkedinURL": "https://www.linkedin.com/in/nadiauddin86/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Farzad Roozitalab",
+                    "title": "Workshop Lead",
+                    "linkedinURL": "https://www.linkedin.com/in/farzad-roozitalab/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "David Hobson",
+                    "title": "Workshop Lead",
+                    "linkedinURL": "https://www.linkedin.com/in/david-hobson-2728661b0/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Abdul Mutakabbir",
+                    "title": "Workshop Lead",
+                    "linkedinURL": "https://www.linkedin.com/in/abdul-mutakabbir-15ab41188/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Khun Thu Rein",
+                    "title": "Webmaster",
+                    "linkedinURL": "https://www.linkedin.com/in/khunthurein77ca/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Rabten Tsering",
+                    "title": "Webmaster",
+                    "linkedinURL": "https://www.linkedin.com/in/rabten-tsering/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Jahnelle Woldegiorgis",
+                    "title": "Social Media Coordinator",
+                    "linkedinURL": "https://www.linkedin.com/in/jahnelle-woldegiorgis/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Itoro Umanah",
+                    "title": "Social Media Coordinator",
+                    "linkedinURL": "https://www.linkedin.com/in/itoro-umanah-a85532210/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Renee Tejani",
+                    "title": "Social Media Coordinator",
+                    "linkedinURL": "https://www.linkedin.com/in/reneetejani/",
+                    "linkedin": "/linkedin.svg"
+                }
+            ]
+        },
+        {
+            "year": "2022-2023",
+            "members": [
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Enos Odigie",
+                    "title": "Co-President",
+                    "linkedinURL": "https://www.linkedin.com/in/enosodigie/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Gordon Tang",
+                    "title": "Co-President & VP Finance",
+                    "linkedinURL": "https://www.linkedin.com/in/gordon-tang-2023/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Kanishk Patoliya",
+                    "title": "VP External and Events",
+                    "linkedinURL": "https://www.linkedin.com/in/kanishk-patoliya/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Nadia Uddin",
+                    "title": "Events Coordinator",
+                    "linkedinURL": "https://www.linkedin.com/in/nadiauddin86/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Farzad Roozitalab",
+                    "title": "Workshop Lead",
+                    "linkedinURL": "https://www.linkedin.com/in/farzad-roozitalab/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "David Hobson",
+                    "title": "Workshop Lead",
+                    "linkedinURL": "https://www.linkedin.com/in/david-hobson-2728661b0/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Khun Thu Rein",
+                    "title": "Webmaster",
+                    "linkedinURL": "https://www.linkedin.com/in/khunthurein77ca/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Rabten Tsering",
+                    "title": "Webmaster",
+                    "linkedinURL": "https://www.linkedin.com/in/rabten-tsering/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Jahnelle Woldegiorgis",
+                    "title": "Social Media Coordinator",
+                    "linkedinURL": "https://www.linkedin.com/in/jahnelle-woldegiorgis/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Itoro Umanah",
+                    "title": "Social Media Coordinator",
+                    "linkedinURL": "https://www.linkedin.com/in/itoro-umanah-a85532210/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Renee Tejani",
+                    "title": "Social Media Coordinator",
+                    "linkedinURL": "https://www.linkedin.com/in/reneetejani/",
+                    "linkedin": "/linkedin.svg"
+                }
+            ]
+        },
+        {
+            "year": "2021-2022",
+            "members": [
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Abdullah Al-Chihabi",
+                    "title": "Co-President",
+                    "linkedinURL": "https://www.linkedin.com/in/abdullahalchihabi/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Gordon Tang",
+                    "title": "Co-President",
+                    "linkedinURL": "https://www.linkedin.com/in/gordon-tang-2023/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Kyle Knobloch",
+                    "title": "VP Events",
+                    "linkedinURL": "https://www.linkedin.com/in/kylejknobloch/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Fareen Lavji",
+                    "title": "VP Finance",
+                    "linkedinURL": "https://www.linkedin.com/in/flavji/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Japinder Sandhu",
+                    "title": "VP Sponsorship",
+                    "linkedinURL": "https://www.linkedin.com/in/japinder-sandhu/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Justin Bellavance",
+                    "title": "VP Development",
+                    "linkedinURL": "https://www.linkedin.com/in/justin-b-bba970129/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Ujan Sen",
+                    "title": "VP External",
+                    "linkedinURL": "https://www.linkedin.com/in/ujansen/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Enos Odigie",
+                    "title": "VP Engagement and Webmaster",
+                    "linkedinURL": "https://www.linkedin.com/in/enosodigie/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Kanishk Patoliya",
+                    "title": "VP Communications and Engagement",
+                    "linkedinURL": "https://www.linkedin.com/in/kanishk-patoliya/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Anoushka Singhal",
+                    "title": "Social Media Coordinator",
+                    "linkedinURL": "https://www.linkedin.com/in/anoushkasinghal/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Samaia Aidroos",
+                    "title": "Social Media Coordinator",
+                    "linkedinURL": "https://www.linkedin.com/in/samaia-aidroos-290757208/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Brian Yang",
+                    "title": "Social Media Coordinator",
+                    "linkedinURL": "https://www.linkedin.com/in/brian-yang-14842020a/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Anh Khoa Tran",
+                    "title": "Workshop Lead",
+                    "linkedinURL": "https://www.linkedin.com/in/anh-khoa-tran/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Victoria Ajila",
+                    "title": "Workshop Lead",
+                    "linkedinURL": "https://www.linkedin.com/in/victoria-ajila-63616914b/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Arushan Sinnadurai",
+                    "title": "Workshop Lead",
+                    "linkedinURL": "https://www.linkedin.com/in/arushan-sinnadurai/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Damilola Adesola",
+                    "title": "Workshop Lead",
+                    "linkedinURL": "https://www.linkedin.com/in/damilola-adesola/",
+                    "linkedin": "/linkedin.svg"
+                },
+                {
+                    "image": "/stockIcon.jpg",
+                    "name": "Ilan Gofman",
+                    "title": "Workshop Lead",
+                    "linkedinURL": "https://www.linkedin.com/in/ilan-gofman/",
+                    "linkedin": "/linkedin.svg"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adds old-teams.json file to the data/ folder, providing Names, Positions, and LinkedIn profiles for all previous executive teams at CAIS. 

Adds OldTeamsRow.tsx component, which serves to display the old team data for one year.

Modifies TeamDisplay.tsx component to incorporate repeated OldTeamsRow components at the bottom of the page.